### PR TITLE
Fix: "AI의 음식 인식 실패시 HTTP처리 및 track_name_dday 라우터 출력요소 변경 요청"

### DIFF
--- a/project/backend/domain/group/group_router.py
+++ b/project/backend/domain/group/group_router.py
@@ -253,7 +253,7 @@ def get_track_name_dday_byDate(daytime: str, current_user: User = Depends(get_cu
     if meal_day is None:
         raise HTTPException(status_code=404, detail="MealDay not found")
     track_name = None
-    track_id = None
+    track_id = -1
     dday = None
     using_track = None
     if meal_day and meal_day.track_id:

--- a/project/backend/domain/meal_hour/meal_hour_router.py
+++ b/project/backend/domain/meal_hour/meal_hour_router.py
@@ -167,7 +167,11 @@ async def upload_food(current_user: User = Depends(get_current_user), file: Uplo
     #Yolov 서버에서 반환된 정보
     food_info = response.json()
     print(food_info)
-
+    food_info_dict = json.loads(food_info)
+    is_success = bool(food_info_dict.get("is_success", False))
+    if is_success == False:
+        temp_blob.delete()
+        raise HTTPException(status_code=400, detail="No food data")
     return {"file_path": temp_blob.name, "food_info": food_info, "image_url": url} ## 임시파일이름, food정보, url 반환
 
 @router.delete("/remove/{times}")


### PR DESCRIPTION
수정사항
 - mealhour/upload_temp 라우터 실행 중 AI 음식 인식 실패시 HTTP raise 코드 추가
 - track/group/name_dday 라우터 실행 시 track이 없을 경우 track.id에 -1 출력으로 변경

Resolves: #74